### PR TITLE
[Bugfix] Bullet Casings

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -717,9 +717,7 @@ end)
 
 RegisterNetEvent('evidence:server:CreateCasing', function(weapon, coords)
     local casingId = generateId(casings)
-    local weaponInfo = QBCore.Shared.Weapons[weapon]
-    local weaponData = exports.ox_inventory:Search(source, 'slots', weaponInfo.name, 'serial')
-    local serieNumber = weaponData[1]?.metadata?.serial
+    local serialNumber = exports.ox_inventory:GetCurrentWeapon(source).metadata.serial
     TriggerClientEvent("evidence:client:AddCasing", -1, casingId, weapon, coords, serieNumber)
 end)
 


### PR DESCRIPTION
## Description
Changes the way serial is fetched when a bullet casing is created.

Should always return the correct serial, by using ox_inventory GetCurrentWeapon export.

Fixes issue with unknow serial.

## Checklist
- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
