### PR TITLE
[FIX] During cuff playerId gets the value of 0

### DIFF
--- a/client/interactions.lua
+++ b/client/interactions.lua
@@ -271,7 +271,7 @@ RegisterNetEvent('police:client:CuffPlayerSoft', function()
     if IsPedRagdoll(cache.ped) then return end
     local player, distance = QBCore.Functions.GetClosestPlayer()
     if isTooFar(player, distance, 1.5) then return end
-    local playerId = GetPlayerServerId(player)
+    local playerId = GetPlayerServerId(NetworkGetPlayerIndexFromPed(player))
     if IsPedInAnyVehicle(GetPlayerPed(player), false) or cache.vehicle then
         lib.notify({ description = Lang:t("error.vehicle_cuff"), type = 'error' })
         return
@@ -289,7 +289,7 @@ RegisterNetEvent('police:client:CuffPlayer', function()
         lib.notify({ description = Lang:t("error.no_cuff"), type = 'error' })
         return
     end
-    local playerId = GetPlayerServerId(player)
+    local playerId = GetPlayerServerId(NetworkGetPlayerIndexFromPed(player))
     if IsPedInAnyVehicle(GetPlayerPed(player), false) or cache.vehicle then
         lib.notify({ description = Lang:t("error.vehicle_cuff"), type = 'error' })
         return


### PR DESCRIPTION
## Description
Fixes the cuffing which not works at this time. playerId variable gets a 0 number value when defined.

## Checklist
- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
