### PR TITLE
[FIX]typo fix

### DIFF
--- a/client/evidence.lua
+++ b/client/evidence.lua
@@ -55,7 +55,7 @@ local function dropBulletCasing(weapon, ped)
     local randX = math.random() + math.random(-1, 1)
     local randY = math.random() + math.random(-1, 1)
     local coords = GetOffsetFromEntityInWorldCoords(ped, randX, randY, 0)
-    local serial = exports.ox_inventory:GetCurrentWeapon().metadata.serial
+    local serial = exports.ox_inventory:getCurrentWeapon().metadata.serial
     TriggerServerEvent('evidence:server:CreateCasing', weapon, serial, coords)
     Wait(300)
 end


### PR DESCRIPTION
## Description
Fixes this error: _@qbx-policejob/client/evidence.lua:58 No such export GetCurrentWeapon in resource ox_inventory_
Ox Reference: (https://overextended.dev/ox_inventory/Functions/Client#getcurrentweapon)

## Checklist
- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
