### PR TITLE
fix(client/server): fix vehicle spawn with extras

### DIFF
--- a/client/job.lua
+++ b/client/job.lua
@@ -104,25 +104,23 @@ local function takeOutVehicle(vehicleInfo)
     local coords = Config.Locations.vehicle[currentGarage]
     if not coords then return end
 
-    QBCore.Functions.TriggerCallback('QBCore:Server:SpawnVehicle', function(netId)
-        local veh = NetToVeh(netId)
-        setCarItemsInfo()
-        SetVehicleNumberPlateText(veh, Lang:t('info.police_plate')..tostring(math.random(1000, 9999)))
-        SetEntityHeading(veh, coords.w)
-        SetVehicleFuelLevel(veh, 100.0)
-        if Config.VehicleSettings[vehicleInfo] then
-            if Config.VehicleSettings[vehicleInfo].extras then
-                QBCore.Shared.SetDefaultVehicleExtras(veh, Config.VehicleSettings[vehicleInfo].extras)
-            end
-            if Config.VehicleSettings[vehicleInfo].livery then
-                SetVehicleLivery(veh, Config.VehicleSettings[vehicleInfo].livery)
-            end
+    local netId = lib.callback.await('qbx-policejob:server:spawnVehicle', false, vehicleInfo, coords, Lang:t('info.police_plate')..tostring(math.random(1000, 9999)))
+    local veh = NetToVeh(netId)
+    setCarItemsInfo()
+    SetEntityHeading(veh, coords.w)
+    SetVehicleFuelLevel(veh, 100.0)
+    if Config.VehicleSettings[vehicleInfo] then
+        if Config.VehicleSettings[vehicleInfo].extras then
+            SetVehicleExtras(veh, Config.VehicleSettings[vehicleInfo].extras)
         end
-        TaskWarpPedIntoVehicle(cache.ped, veh, -1)
-        TriggerEvent("vehiclekeys:client:SetOwner", QBCore.Functions.GetPlate(veh))
-        TriggerServerEvent("inventory:server:addTrunkItems", QBCore.Functions.GetPlate(veh), Config.CarItems)
-        SetVehicleEngineOn(veh, true, true, false)
-    end, vehicleInfo, coords, true)
+        if Config.VehicleSettings[vehicleInfo].livery then
+            SetVehicleLivery(veh, Config.VehicleSettings[vehicleInfo].livery)
+        end
+    end
+    TaskWarpPedIntoVehicle(cache.ped, veh, -1)
+    TriggerEvent("vehiclekeys:client:SetOwner", QBCore.Functions.GetPlate(veh))
+    TriggerServerEvent("inventory:server:addTrunkItems", QBCore.Functions.GetPlate(veh), Config.CarItems)
+    SetVehicleEngineOn(veh, true, true, false)
 end
 
 local function openGarageMenu()

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -9,34 +9,39 @@ shared_scripts {
     '@qbx-core/shared/locale.lua',
     'locales/en.lua',
     'locales/*.lua',
-	'@ox_lib/init.lua'
+    '@ox_lib/init.lua',
+    '@qbx-core/import.lua'
+}
+
+modules {
+    'qbx-core:utils'
 }
 
 client_scripts {
-	'client/main.lua',
-	'client/camera.lua',
-	'client/interactions.lua',
-	'client/job.lua',
-	'client/heli.lua',
-	'client/anpr.lua',
-	'client/evidence.lua',
-	'client/objects.lua',
-	'client/tracker.lua'
+    'client/main.lua',
+    'client/camera.lua',
+    'client/interactions.lua',
+    'client/job.lua',
+    'client/heli.lua',
+    'client/anpr.lua',
+    'client/evidence.lua',
+    'client/objects.lua',
+    'client/tracker.lua'
 }
 
 server_scripts {
-	'@oxmysql/lib/MySQL.lua',
-	'server/main.lua'
+    '@oxmysql/lib/MySQL.lua',
+    'server/main.lua'
 }
 
 ui_page 'html/index.html'
 
 files {
-	'html/index.html',
-	'html/vue.min.js',
-	'html/script.js',
-	'html/fingerprint.png',
-	'html/main.css'
+    'html/index.html',
+    'html/vue.min.js',
+    'html/script.js',
+    'html/fingerprint.png',
+    'html/main.css'
 }
 
 lua54 'yes'

--- a/server/main.lua
+++ b/server/main.lua
@@ -372,6 +372,17 @@ lib.callback.register('police:GetImpoundedVehicles', function()
     end
 end)
 
+lib.callback.register('qbx-policejob:server:spawnVehicle', function(source, model, coords, plate)
+    local netId = QBCore.Functions.CreateVehicle(source, model, coords, true)
+    if not netId or netId == 0 then return end
+    local veh = NetworkGetEntityFromNetworkId(netId)
+    if not veh or veh == 0 then return end
+
+    SetVehicleNumberPlateText(veh, plate)
+    TriggerClientEvent('vehiclekeys:client:SetOwner', source, plate)
+    return netId
+end)
+
 local function isPlateFlagged(plate)
     return plates and plates[plate] and plates[plate].isflagged
 end


### PR DESCRIPTION
## Description

- This fixes setting vehicle extras after applying the fix on qbx-core
- Moved the callback to ox_lib

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
