### PR TITLE
refactor(server): moved sql queries to storage.lua

### DIFF
--- a/server/storage.lua
+++ b/server/storage.lua
@@ -1,0 +1,23 @@
+function IsVehicleOwned(plate)
+    local count = MySQL.scalar.await('SELECT count(*) FROM player_vehicles WHERE plate = ?', {plate})
+    return count > 0
+end
+
+function FetchImpoundedVehicles()
+    local result = MySQL.query.await('SELECT * FROM player_vehicles WHERE state = 2')
+    if result[1] then
+        return result
+    end
+end
+
+function Unimpound(plate)
+    MySQL.update('UPDATE player_vehicles SET state = 0 WHERE plate = ?', {plate})
+end
+
+function ImpoundWithPrice(price, body, engine, fuel, plate)
+    MySQL.query('UPDATE player_vehicles SET state = 0, depotprice = ?, body = ?, engine = ?, fuel = ? WHERE plate = ?', {price, body, engine, fuel, plate})
+end
+
+function ImpoundForever(body, engine, fuel, plate)
+    MySQL.query('UPDATE player_vehicles SET state = 2, body = ?, engine = ?, fuel = ? WHERE plate = ?', {body, engine, fuel, plate})
+end


### PR DESCRIPTION
## Description
- moved the sql calls to storage.lua. This surfaces how this resource interacts with storage and makes it easier to refactor later when doing any sort of schema change.
- also snuck in changing a table to a vec4

## Checklist

- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
